### PR TITLE
Update oval_org.cisecurity_def_2203.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_2203.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_2203.xml
@@ -31,7 +31,7 @@
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>
-  <criteria comment="Microsoft .NET Framework 4.7 is installed" operator="OR">
+  <criteria operator="OR">
     <criterion comment="Check if the release of .Net framework 4.7 (full) is equal to 460798" test_ref="oval:org.cisecurity:tst:3012" />
     <criterion comment="Check if the release of .Net framework 4.7 (client) is equal to 460798" test_ref="oval:org.cisecurity:tst:3017" />
     <criterion comment="Check if the release of .Net framework 4.7 (full) is equal to 460805" test_ref="oval:org.cisecurity:tst:3711" />


### PR DESCRIPTION
Comment on the definition's root criteria element should not be set.